### PR TITLE
Child classes must match signature of extended parent classes

### DIFF
--- a/plivo.php
+++ b/plivo.php
@@ -660,8 +660,8 @@ class Response extends Element {
         parent::__construct(NULL);
     }
 
-    public function toXML() {
-        $xml = parent::toXML($header=TRUE);
+    public function toXML($header=FALSE) {
+        $xml = parent::toXML(TRUE);
         return $xml;
     }
 }


### PR DESCRIPTION
"function Response::toXML()" must be defined as "function Response::toXML($header=FALSE)" or else E_STRICT warnings are thrown. To replicate this,
set "error_reporting  =  E_ALL | E_STRICT".

The next line "parent::toXML(TRUE)" correctly calls the parent with the correct parameter.