### PR TITLE
Exclude namespace from element's name

### DIFF
--- a/plivo.php
+++ b/plivo.php
@@ -588,7 +588,8 @@ class Element {
         if ((!$attributes) || ($attributes === null)) {
             $this->attributes = array();
         }
-        $this->name = get_class($this);
+        $this->name = preg_replace('/^'.__NAMESPACE__.'\\\\/', '', get_class($this));
+
         $this->body = $body;
         foreach ($this->attributes as $key => $value) {
             if (!in_array($key, $this->valid_attributes)) {


### PR DESCRIPTION
I know it's a dev branch and it's stalled for three months now, but that's the only thing I see that makes it not work. Namespace should not be included in element's name — we don't really want `<Plivio\Response />` tags. :wink:

Refs #14.