### PR TITLE
fix for E_STRICT error: Strict Standards: Declaration of Response::toXML() should be compatible with Element::toXML($header = false) in plivo.php on line 768

### DIFF
--- a/plivo.php
+++ b/plivo.php
@@ -761,8 +761,8 @@ class Response extends Element {
         parent::__construct(NULL);
     }
 
-    public function toXML() {
-        $xml = parent::toXML($header=TRUE);
+    public function toXML($header=FALSE) {
+        $xml = parent::toXML(TRUE);
         return $xml;
     }
 }


### PR DESCRIPTION
This bug has been fixed in dev branch but since that branch is not stable yet, here’s the same fix for the stable master branch.