### PR TITLE
Update plivo.php

### DIFF
--- a/plivo.php
+++ b/plivo.php
@@ -2,8 +2,6 @@
 
 namespace Plivo;
 
-require 'vendor/autoload.php';
-
 use Guzzle\Http\Client;
 
 class PlivoError extends \Exception {}


### PR DESCRIPTION
When using this library, "vendor/autoload.php" will not exist, and it will fail with an error.