### PR TITLE
Use message_uuid parameter in get_message() function

### DIFF
--- a/plivo.php
+++ b/plivo.php
@@ -67,10 +67,10 @@ class RestAPI {
     }
 
     private function pop($params, $key) {
-        $val = $params[ $key ];
-        if (!$val) {
+        if (!key_exists($key, $params)) {
             throw new PlivoError($key." parameter not found");
         }
+        $val = $params[ $key ];
         unset($params[ $key ]);
 
         return $val;
@@ -561,9 +561,9 @@ class RestAPI {
     }
 
     public function get_message($params = array()) {
-        $record_id = $this->pop($params, 'record_id');
+        $message_uuid = $this->pop($params, 'message_uuid');
 
-        return $this->request('GET', '/Message/'.$record_id.'/', $params);
+        return $this->request('GET', '/Message/'.$message_uuid.'/', $params);
     }
 }
 


### PR DESCRIPTION
I have fixed parameter `message_uuid` in get_message() by removing old parameter `record_id`. There is parameter `message_uuid` in [docs](https://www.plivo.com/docs/helpers/php/) in Message API section.
Also I've fixed undefined index error in `pop()` function. 