### PR TITLE
Simplify test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .DS_STORE
 phpDocumentor.phar
+phpunit.xml
 generateDocs.sh
 composer.phar
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
   # - hhvm # on Trusty only
   - nightly
 before_install: "composer install"
-script: "phpunit --configuration tests/phpunit.xml"
+script: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,17 @@
         "guzzlehttp/guzzle": "^6.0"
     },
     "autoload": {
-        "classmap": ["src/", "tests/"],
-        "exclude-from-classmap": []
+        "psr-4": {
+            "Plivo\\": "src/Plivo/"
+        }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0",
         "justinrainbow/json-schema": "^5.2"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Plivo\\Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="plivo-php">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -56,11 +56,10 @@ class BaseTestCase extends TestCase
      */
     public function expectPlivoException($exception)
     {
-        if (version_compare(phpversion(), '7.0.0', '<')) {
-            self::setExpectedException($exception);
-        } else {
+        if (method_exists(__CLASS__, 'expectException')) {
             self::expectException($exception);
+        } else {
+            self::setExpectedException($exception);
         }
-
     }
 }

--- a/tests/Resources/AccountTest.php
+++ b/tests/Resources/AccountTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/ApplicationTest.php
+++ b/tests/Resources/ApplicationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/CallTest.php
+++ b/tests/Resources/CallTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/ConferenceTest.php
+++ b/tests/Resources/ConferenceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/EndpointTest.php
+++ b/tests/Resources/EndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/NumberTest.php
+++ b/tests/Resources/NumberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/PhoneNumberTest.php
+++ b/tests/Resources/PhoneNumberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/PricingTest.php
+++ b/tests/Resources/PricingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/Resources/RecordingTest.php
+++ b/tests/Resources/RecordingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Resources;
+namespace Plivo\Tests\Resources;
 
 
 use Plivo\Http\PlivoRequest;

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use Plivo\Tests\BaseTestCase;
+namespace Plivo\Tests;
+
 use Plivo\Util\signatureValidation;
 
 

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use Plivo\Tests\BaseTestCase;
+namespace Plivo\Tests;
+
 use Plivo\XML\Response;
 
 
@@ -20,7 +21,7 @@ class XmlTest extends BaseTestCase
                 ['callbackUrl' => "http://foo.com/confevents/",
                 'callbackMethod' => "POST",
                 'digitsMatch' => "#0,99,000"]);
-        
+
         $dial = $resp->addDial(
             [
                 'confirmSound' => "http://foo.com/sound/",
@@ -34,7 +35,7 @@ class XmlTest extends BaseTestCase
             [
                 'sendDigits' => "wwww2410"
             ]);
-        
+
         $dial1 = $resp->addDial(
             [
                 'timeout' => "20",
@@ -45,28 +46,28 @@ class XmlTest extends BaseTestCase
 
         $dial2 = $resp->addDial([]);
         $dial2->addNumber("15671234567", []);
-        
+
         $resp->addDTMF("12345", []);
-        
+
         $get_digits = $resp->addGetDigits(
             [
                 'action' => "http://www.foo.com/gather_pin/",
                 "method" => "POST"
             ]);
-        
+
         $get_digits->addSpeak("Enter PIN number.", []);
         $resp->addSpeak("Input not recieved.", []);
-        
+
         $resp->addHangup(
             [
                 'schedule' => "60",
-                'reason' => "rejected" 
+                'reason' => "rejected"
             ]);
         $resp->addSpeak("Call will hangup after a min.",
             [
                 'loop' => "0"
             ]);
-        
+
         $resp->addMessage("Hi, message from Plivo.",
             [
                 'src' => "12023222222",
@@ -75,13 +76,13 @@ class XmlTest extends BaseTestCase
                 'callbackUrl' => "http://foo.com/sms_status/",
                 'callbackMethod' => "POST"
             ]);
-        
+
         $resp->addPlay("https://amazonaws.com/Trumpet.mp3", []);
-        
+
         $answer = $resp->addPreAnswer();
         $answer->addSpeak("This call will cost $2 a min.", []);
         $resp->addSpeak("Thanks for dropping by.", []);
-        
+
         $resp->addRecord(
             [
                 'action' => "http://foo.com/get_recording/",
@@ -92,51 +93,51 @@ class XmlTest extends BaseTestCase
         $dial3 = $resp->addDial([]);
 
         $dial3->addNumber("15551234567", []);
-        
+
         $resp->addSpeak("Leave message after the beep.", []);
         $resp->addRecord(
-            [   
+            [
                 'action' => "http://foo.com/get_recording/",
                 'maxLength' => "30",
                 'finishOnKey' => "*"
             ]);
         $resp->addSpeak("Recording not received.", []);
-        
+
         $resp->addSpeak("Your call is being transferred.", []);
         $resp->addRedirect("http://foo.com/redirect/", []);
-        
+
         $resp->addSpeak("Go green, go plivo.",
             [
                 'loop' => "3"
             ]);
-        
+
         $resp->addSpeak("I will wait 7 seconds starting now!", []);
         $resp->addWait(
             [
                 'length' => "7"
             ]);
         $resp->addSpeak("I just waited 7 seconds.", []);
-        
+
         $resp->addWait(
             [
                 'length' => "120", 'beep' => "true"
             ]);
         $resp->addPlay("https://s3.amazonaws.com/abc.mp3", []);
-        
+
         $resp->addWait(
             [
                 'length' => "10"
             ]);
         $resp->addSpeak("Hello", []);
-        
+
         $resp->addWait(
             [
                 'length' => "10",
-                'silence' => "true", 
+                'silence' => "true",
                 'minSilence' => "3000"
             ]);
         $resp->addSpeak("Hello, welcome to the Jungle.", []);
-      
+
         $output = $resp->toXML(true);
         self::assertEquals(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Response><Conference callbackUrl=\"http://foo.com/confevents/\" callbackMethod=\"POST\" digitsMatch=\"#0,99,000\">My room</Conference><Dial confirmSound=\"http://foo.com/sound/\" confirmKey=\"3\"><Number sendDigits=\"wwww2410\">18217654321</Number><User sendDigits=\"wwww2410\">sip:john1234@phone.plivo.com</User></Dial><Dial timeout=\"20\" action=\"http://oo.com/dial_action/\"><Number>18217654321</Number></Dial><Dial><Number>15671234567</Number></Dial><DTMF>12345</DTMF><GetDigits action=\"http://www.foo.com/gather_pin/\" method=\"POST\"><Speak>Enter PIN number.</Speak></GetDigits><Speak>Input not recieved.</Speak><Hangup schedule=\"60\" reason=\"rejected\"/><Speak loop=\"0\">Call will hangup after a min.</Speak><Message src=\"12023222222\" dst=\"15671234567\" type=\"sms\" callbackUrl=\"http://foo.com/sms_status/\" callbackMethod=\"POST\">Hi, message from Plivo.</Message><Play>https://amazonaws.com/Trumpet.mp3</Play><PreAnswer><Speak>This call will cost $2 a min.</Speak></PreAnswer><Speak>Thanks for dropping by.</Speak><Record action=\"http://foo.com/get_recording/\" startOnDialAnswer=\"true\" redirect=\"false\"/><Dial><Number>15551234567</Number></Dial><Speak>Leave message after the beep.</Speak><Record action=\"http://foo.com/get_recording/\" maxLength=\"30\" finishOnKey=\"*\"/><Speak>Recording not received.</Speak><Speak>Your call is being transferred.</Speak><Redirect>http://foo.com/redirect/</Redirect><Speak loop=\"3\">Go green, go plivo.</Speak><Speak>I will wait 7 seconds starting now!</Speak><Wait length=\"7\"/><Speak>I just waited 7 seconds.</Speak><Wait length=\"120\" beep=\"true\"/><Play>https://s3.amazonaws.com/abc.mp3</Play><Wait length=\"10\"/><Speak>Hello</Speak><Wait length=\"10\" silence=\"true\" minSilence=\"3000\"/><Speak>Hello, welcome to the Jungle.</Speak></Response>\n",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-error_reporting(E_ALL | E_STRICT);
-require dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="resources-tests">
-            <directory suffix="Test.php">./</directory>
-        </testsuite>
-    </testsuites>
-</phpunit>


### PR DESCRIPTION
This pull request simplifies the setup to run the test cases:

 * Use built-in autoloader for tests
 * Use PHPUnit binary as specified in `composer.json`
 * Use newer PHPUnit version if supported
 * Fix check for `expectedException`/`setExpectedException`
 * Add missing namespace declarations

These changes should not introduce any BC breaks.