### PR TITLE
Validate signature of PSR-7 messages and superglobals

### DIFF
--- a/src/Plivo/Util/signatureValidation.php
+++ b/src/Plivo/Util/signatureValidation.php
@@ -2,6 +2,9 @@
 
 namespace Plivo\Util;
 
+use GuzzleHttp\Psr7\ServerRequest;
+use Psr\Http\Message\RequestInterface;
+
 
 /**
  * Class signatureValidation
@@ -33,5 +36,26 @@ class signatureValidation
       $hmac = hash_hmac('SHA256', $base_url.$nonce, $auth_token, true);
       $authentication_string = base64_encode($hmac);
       return $authentication_string == $signature;
+    }
+
+    /**
+     * Validate the signature of a request
+     *
+     * @param string $authToken
+     * @param RequestInterface|null $request
+     *
+     * @return bool
+     */
+    public static function validateRequest($authToken, RequestInterface $request = null)
+    {
+        if ($request === null) {
+            $request = ServerRequest::fromGlobals();
+        }
+
+        $uri = (string) $request->getUri();
+        $nonce = $request->getHeaderLine('X-Plivo-Signature-V2-Nonce');
+        $signature = $request->getHeaderLine('X-Plivo-Signature-V2');
+
+        return self::validateSignature($uri, $nonce, $signature, $authToken);
     }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use Plivo\Tests\BaseTestCase;
+namespace Plivo\Tests;
+
+use GuzzleHttp\Psr7\Request;
 use Plivo\Util\signatureValidation;
 
 
@@ -16,10 +18,26 @@ class UtilTest extends BaseTestCase
         $output = $SVUtil->validateSignature('https://answer.url','12345','ehV3IKhLysWBxC1sy8INm0qGoQYdYsHwuoKjsX7FsXc=','my_auth_token');
         self::assertEquals($output,True);
     }
+
     function testSignatureInvalid()
     {
         $SVUtil = new signatureValidation();
         $output = $SVUtil->validateSignature('https://answer.url','12345','ehV3IKhLysWBxC1sy8INm0qGoQYdYsHwuoKjsX7FsXc=','my_auth_tokens');
         self::assertEquals($output,False);
+    }
+
+    function testRequestValid()
+    {
+        $request = new Request('GET', 'https://answer.url/callback?a=b', [
+            'X-Plivo-Signature-V2' => 'K35dKDFR7qol4IYq+4/3qx2+KVXUWF/mHJg3Pxp7VAo=',
+            'X-Plivo-Signature-V2-Nonce' => '12345',
+        ]);
+
+        self::assertSame(true, signatureValidation::validateRequest('my_auth_token', $request));
+    }
+
+    function testRequestInvalid()
+    {
+        self::assertSame(false, signatureValidation::validateRequest('my_auth_token'));
     }
 }


### PR DESCRIPTION
This pull request adds a method to easily check if the signature of a request is valid. You no longer have to parse the headers yourself. In addition, PSR-7 messages can be validated too. This reduces the boilerplate when integrating the SDK in many frameworks (Symfony, Zend, ...).

Example:
```php
<?php
require_once __DIR__.'/vendor/autoload.php';
if (!Plivo\Util\signatureValidation::validateRequest('my_auth_token')) {
    die('Invalid signature.');
}
// your application logic
```