### PR TITLE
Fix exception on invalid request

### DIFF
--- a/src/Plivo/BaseClient.php
+++ b/src/Plivo/BaseClient.php
@@ -168,7 +168,7 @@ class BaseClient
         static::$requestCount++;
 
         if (!$plivoResponse->ok()) {
-            return $plivoResponse;
+            throw $plivoResponse->getThrownException();
         }
 
         return $plivoResponse;


### PR DESCRIPTION
This PR (https://github.com/plivo/plivo-php/pull/99/files) which should just have added some documentation examples, removed throwing an exception if the request was not ok. I do not think this was on purpose but was then made for debug reasons and the change has been forgotten to be removed before pushing.

This change is probably the reason for some of the issues here (https://github.com/plivo/plivo-php/issues/171, https://github.com/plivo/plivo-php/issues/168, https://github.com/plivo/plivo-php/issues/143, https://github.com/plivo/plivo-php/issues/135).