### PR TITLE
Add Lookup API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-09-15
+- Add support for Lookup API.
+
 ## [v4.11.1](https://github.com/plivo/plivo-php/releases/tag/v4.11.1) - 2020-09-17
 - Fix "Media is invalid" error while using Send MMS API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-09-15
+## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-09-21
 - Add support for Lookup API.
 
 ## [v4.11.1](https://github.com/plivo/plivo-php/releases/tag/v4.11.1) - 2020-09-17

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ require 'vendor/autoload.php';
 use Plivo\RestClient;
 
 $client = new RestClient("AUTH_ID", "AUTH_TOKEN");
-$response = $client->lookup->get("<number-goes-here>", "service_provider");
+$response = $client->lookup->get("<number-goes-here>", "carrier");
 ```
 
 ### Generate Plivo XML

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Plivo PHP SDK makes it simpler to integrate communications into your PHP app
 
 - To install a **specific release**, run the following command in the project directory:
         
-        $ composer require plivo/plivo-php:4.9.0
+        $ composer require plivo/plivo-php:4.12.0
 
 - To test the features in the **beta release**, run the following command in the project directory:
         
@@ -162,6 +162,17 @@ $call_made = $client->calls->create(
     ['the_destination_number'],
     'https://answer.url'
 );
+```
+
+### Lookup a number
+
+```php
+<?php
+require 'vendor/autoload.php';
+use Plivo\RestClient;
+
+$client = new RestClient("AUTH_ID", "AUTH_TOKEN");
+$response = $client->lookup->get("<number-goes-here>", "service_provider");
 ```
 
 ### Generate Plivo XML

--- a/src/Plivo/Resources/Lookup/LookupInterface.php
+++ b/src/Plivo/Resources/Lookup/LookupInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Plivo\Resources\Lookup;
+
+use Plivo\BaseClient;
+use Plivo\Resources\ResourceInterface;
+
+/**
+ * Class LookupInterface
+ * @package Plivo\Resources\Lookup
+ */
+class LookupInterface extends ResourceInterface
+{
+    /**
+     * LookupInterface constructor.
+     * @param BaseClient $plivoClient
+     */
+    public function __construct(BaseClient $plivoClient)
+    {
+        parent::__construct($plivoClient);
+        $this->uri = "Lookup/Number/";
+    }
+
+    /**
+     * Lookup a phone number.
+     * @param number
+     * @param info
+     */
+    public function get($number, $info = "service_provider")
+    {
+        $uri = $this->uri . $number . '?info=' . $info;
+        $response = $this->client->fetch(
+            $uri,
+            []
+        );
+
+        // returns a nested associative array and is better than subclassing
+        // from Resource class since there is no further use for client.
+        return $response->getContent();
+    }
+}

--- a/src/Plivo/Resources/Lookup/LookupInterface.php
+++ b/src/Plivo/Resources/Lookup/LookupInterface.php
@@ -24,11 +24,11 @@ class LookupInterface extends ResourceInterface
     /**
      * Lookup a phone number.
      * @param number
-     * @param info
+     * @param type
      */
-    public function get($number, $info = "service_provider")
+    public function get($number, $type = "carrier")
     {
-        $uri = $this->uri . $number . '?info=' . $info;
+        $uri = $this->uri . $number . '?type=' . $type;
         $response = $this->client->fetch(
             $uri,
             []

--- a/src/Plivo/RestClient.php
+++ b/src/Plivo/RestClient.php
@@ -11,6 +11,7 @@ use Plivo\Resources\Endpoint\EndpointInterface;
 use Plivo\Resources\Message\MessageInterface;
 use Plivo\Resources\Powerpack\PowerpackInterface;
 use Plivo\Resources\Media\MediaInterface;
+use Plivo\Resources\Lookup\LookupInterface;
 use Plivo\Resources\Number\NumberInterface;
 use Plivo\Resources\PhoneNumber\PhoneNumberInterface;
 use Plivo\Resources\Pricing\PricingInterface;
@@ -28,7 +29,8 @@ use Plivo\Resources\CallFeedback\CallFeedbackInterface;
  * @property AccountInterface account Interface to handle all Account related api calls
  * @property MessageInterface message Interface to handle all Message related api calls
  * @property PowerpackInterface powerpack Interface to handle all Powerpack related api calls
- * @property MediaInterface media Interface to handle all upload mms media api 
+ * @property MediaInterface media Interface to handle all upload mms media api
+ * @property LookupInterface lookup Interface to handle calls to the Lookup API
  * @property EndpointInterface endpoint Interface to handle all Endpoint related api calls
  * @property NumberInterface number Interface to handle all Number related api calls
  * @property PhoneNumberInterface phoneNumber Interface to handle all PhoneNumber related api calls
@@ -67,6 +69,11 @@ class RestClient
      * @var MediaInterface
      */
     protected $_media;
+
+     /**
+     * @var LookupInterface
+     */
+    protected $_lookup;
 
     /**
      * @var ApplicationInterface
@@ -130,10 +137,17 @@ class RestClient
         $proxyHost = null,
         $proxyPort = null,
         $proxyUsername = null,
-        $proxyPassword = null)
-    {
+        $proxyPassword = null
+    ) {
+
         $this->client = new BaseClient(
-            $authId, $authToken, $proxyHost, $proxyPort, $proxyUsername, $proxyPassword);
+            $authId,
+            $authToken,
+            $proxyHost,
+            $proxyPort,
+            $proxyUsername,
+            $proxyPassword
+        );
         $this->msgClient = new MessageClient($authId, $authToken, $proxyHost, $proxyPort, $proxyUsername, $proxyPassword);
     }
 
@@ -194,6 +208,17 @@ class RestClient
             $this->_media = new MediaInterface($this->client, $this->client->getAuthId());
         }
         return $this->_media;
+    }
+
+    /**
+     * @return LookupInterface
+     */
+    protected function getLookup()
+    {
+        if (!$this->_lookup) {
+            $this->_lookup = new LookupInterface($this->client);
+        }
+        return $this->_lookup;
     }
 
     /**

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -2,7 +2,6 @@
 
 namespace Plivo;
 
-
 /**
  * Class Version
  * @package Plivo
@@ -21,11 +20,11 @@ class Version
     /**
      * @const int PHP helper library minor version number
      */
-    const MINOR = 11;
+    const MINOR = 12;
     /**
      * @const int PHP helper library patch number
      */
-    const PATCH = 1;
+    const PATCH = 0;
     /**
      * @return string
      */

--- a/tests/Mocks/lookupGetResponse.json
+++ b/tests/Mocks/lookupGetResponse.json
@@ -1,0 +1,21 @@
+{
+    "api_id": "930692a3-6f09-45b5-80f5-5585565fb30e",
+    "country": {
+        "code_iso2": "US",
+        "code_iso3": "USA",
+        "name": "United States"
+    },
+    "number_format": {
+        "e164": "+14154305555",
+        "international": "+1 415-430-5555",
+        "national": "(415) 430-5555",
+        "rfc3966": "tel:+1-415-430-5555"
+    },
+    "service_provider": {
+        "mobile_country_code": "310",
+        "mobile_network_code": "160",
+        "name": "Cingular Wireless",
+        "ported": true,
+        "type": "mobile"
+    }
+}

--- a/tests/Mocks/lookupGetResponse.json
+++ b/tests/Mocks/lookupGetResponse.json
@@ -1,21 +1,23 @@
 {
-    "api_id": "930692a3-6f09-45b5-80f5-5585565fb30e",
-    "country": {
-        "code_iso2": "US",
-        "code_iso3": "USA",
-        "name": "United States"
-    },
-    "number_format": {
-        "e164": "+14154305555",
-        "international": "+1 415-430-5555",
-        "national": "(415) 430-5555",
-        "rfc3966": "tel:+1-415-430-5555"
-    },
-    "service_provider": {
-        "mobile_country_code": "310",
-        "mobile_network_code": "160",
-        "name": "Cingular Wireless",
-        "ported": true,
-        "type": "mobile"
-    }
+  "api_id": "a35a2e7a-fd27-42e6-910c-33382f43240e",
+  "phone_number": "+14154305555",
+  "country": {
+    "name": "United States",
+    "code_iso2": "US",
+    "code_iso3": "USA"
+  },
+  "format": {
+    "e164": "+14154305555",
+    "national": "(415) 430-5555",
+    "international": "+1 415-430-5555",
+    "rfc3966": "tel:+1-415-430-5555"
+  },
+  "carrier": {
+    "mobile_country_code": "310",
+    "mobile_network_code": "150",
+    "name": "Cingular Wireless",
+    "type": "mobile",
+    "ported": true
+  },
+  "resource_uri": "/v1/Lookup/Number/+14154305555?type=carrier"
 }

--- a/tests/Resources/LookupTest.php
+++ b/tests/Resources/LookupTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Plivo\Tests\Resources;
+
+use Plivo\Http\PlivoRequest;
+use Plivo\Http\PlivoResponse;
+use Plivo\Tests\BaseTestCase;
+
+/**
+ * Class LookupTest
+ * @package Plivo\Tests\Resources
+ */
+class LookupTest extends BaseTestCase
+{
+
+    public function testLookupGet()
+    {
+        $number = "+14154305555";
+        $request = new PlivoRequest(
+            'GET',
+            'Lookup/Number/'.$number.'?info=service_provider',
+            []
+        );
+        $body = file_get_contents(__DIR__ . '/../Mocks/lookupGetResponse.json');
+        $this->mock(new PlivoResponse($request, 200, $body));
+
+        $actual = $this->client->lookup->get($number);
+        $this->assertRequest($request);
+
+        self::assertNotNull($actual);
+        self::assertEquals($actual["number_format"]["e164"], $number);
+    }
+}

--- a/tests/Resources/LookupTest.php
+++ b/tests/Resources/LookupTest.php
@@ -18,7 +18,7 @@ class LookupTest extends BaseTestCase
         $number = "+14154305555";
         $request = new PlivoRequest(
             'GET',
-            'Lookup/Number/'.$number.'?info=service_provider',
+            'Lookup/Number/'.$number.'?type=carrier',
             []
         );
         $body = file_get_contents(__DIR__ . '/../Mocks/lookupGetResponse.json');
@@ -28,6 +28,8 @@ class LookupTest extends BaseTestCase
         $this->assertRequest($request);
 
         self::assertNotNull($actual);
-        self::assertEquals($actual["number_format"]["e164"], $number);
+        self::assertEquals($actual["phone_number"], $number);
+        self::assertEquals($actual["format"]["e164"], $number);
+        self::assertEquals($actual["resource_uri"], "/v1/Lookup/Number/+14154305555?type=carrier");
     }
 }


### PR DESCRIPTION
Sample program:

```ph
<?php
require 'vendor/autoload.php';
use Plivo\RestClient;
 
$client = new RestClient("XXXX", "XXXX");

try {
    $response = $client->lookup->get("+14154305555", "carrier");
    var_dump($response);
} catch (PlivoRestException $ex) {
    print_r(ex);
}
```

```php
array(6) {
  ["api_id"]=>
  string(36) "f7e4956f-7ab6-4f27-9e95-4c96b2ec4325"
  ["phone_number"]=>
  string(12) "+14154305555"
  ["country"]=>
  array(3) {
    ["name"]=>
    string(13) "United States"
    ["code_iso2"]=>
    string(2) "US"
    ["code_iso3"]=>
    string(3) "USA"
  }
  ["format"]=>
  array(4) {
    ["e164"]=>
    string(12) "+14154305555"
    ["national"]=>
    string(14) "(415) 430-5555"
    ["international"]=>
    string(15) "+1 415-430-5555"
    ["rfc3966"]=>
    string(19) "tel:+1-415-430-5555"
  }
  ["carrier"]=>
  array(5) {
    ["mobile_country_code"]=>
    string(3) "310"
    ["mobile_network_code"]=>
    string(3) "150"
    ["name"]=>
    string(17) "Cingular Wireless"
    ["type"]=>
    string(6) "mobile"
    ["ported"]=>
    bool(true)
  }
  ["resource_uri"]=>
  string(43) "/v1/Lookup/Number/+14154305555?type=carrier"
}
```