### PR TITLE
guzzle http version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
-## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-10-06
-- Upgarde Guzzle Http cleint Version 6 to 7.
+## [v4.13.0](https://github.com/plivo/plivo-php/releases/tag/v4.13.0) - 2020-10-13
+- Add support to Guzzle HTTP client 7.
 
 ## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-09-21
 - Add support for Lookup API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-10-06
+- Upgarde Guzzle Http cleint Version 6 to 7.
 
 ## [v4.11.1](https://github.com/plivo/plivo-php/releases/tag/v4.11.1) - 2020-09-17
 - Fix "Media is invalid" error while using Send MMS API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v4.13.0](https://github.com/plivo/plivo-php/releases/tag/v4.13.0) - 2020-10-13
 - Add support to Guzzle HTTP client 7.
-- Fix "issue-168", _Undefined index: from_number_ error - Retrieve Message Details API with Invalid or not existing message UUID.
+- Fix "issue-168", _Undefined index: from_number_ error - Retrieve Message Details API with Invalid message UUID.
 
 ## [v4.12.0](https://github.com/plivo/plivo-php/releases/tag/v4.12.0) - 2020-09-21
 - Add support for Lookup API.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The Plivo PHP SDK makes it simpler to integrate communications into your PHP applications using the Plivo REST API. Using the SDK, you will be able to make voice calls, send SMS and generate Plivo XML to control your call flows.
 
+**Supported PHP Versions**: This SDK works with PHP 7.1.0+.
+
 ## Installation
 
 ### To install Composer

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/plivo/plivo-php"
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.0",
         "firebase/php-jwt": "^5.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "source": "https://github.com/plivo/plivo-php"
     },
     "require": {
-        "guzzlehttp/guzzle": "^7.0",
+        "php": ">=7.1.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "firebase/php-jwt": "^5.2"
     },
     "autoload": {

--- a/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
+++ b/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
@@ -10,7 +10,7 @@ use Plivo\Http\PlivoRequest;
 use Plivo\Http\PlivoResponse;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 
 
 /**
@@ -131,7 +131,7 @@ class PlivoGuzzleHttpClient implements PlivoHttpClientInterface
         }
         try {
             $rawResponse = $this->guzzleClient->request($method, $url, $options);
-        } catch (RequestException $e) {
+        } catch (TransferException $e) {
             throw new PlivoRequestException($e->getMessage());
         }
         $rawHeaders = $rawResponse->getHeaders();

--- a/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
+++ b/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
@@ -10,7 +10,7 @@ use Plivo\Http\PlivoRequest;
 use Plivo\Http\PlivoResponse;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Exception\RequestException;
 
 
 /**
@@ -131,7 +131,7 @@ class PlivoGuzzleHttpClient implements PlivoHttpClientInterface
         }
         try {
             $rawResponse = $this->guzzleClient->request($method, $url, $options);
-        } catch (TransferException $e) {
+        } catch (RequestException $e) {
             throw new PlivoRequestException($e->getMessage());
         }
         $rawHeaders = $rawResponse->getHeaders();

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -21,7 +21,7 @@ class Version
     /**
      * @const int PHP helper library minor version number
      */
-    const MINOR = 11;
+    const MINOR = 12;
     /**
      * @const int PHP helper library patch number
      */

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -20,7 +20,7 @@ class Version
     /**
      * @const int PHP helper library minor version number
      */
-    const MINOR = 12;
+    const MINOR = 13;
     /**
      * @const int PHP helper library patch number
      */


### PR DESCRIPTION
In order to take advantage of the new features of PHP, Guzzle dropped the support of PHP 5. The minimum supported PHP version is now PHP 7.2. Type hints and return types for functions and methods have been added wherever possible.

Please make sure:

You are calling a function or a method with the correct type.
If you extend a class of Guzzle; update all signatures on methods you override.
Other backwards compatibility breaking changes
Class GuzzleHttp\UriTemplate is removed.
Class GuzzleHttp\Exception\SeekException is removed.
Classes GuzzleHttp\Exception\BadResponseException, GuzzleHttp\Exception\ClientException, GuzzleHttp\Exception\ServerException can no longer be initialized with an empty Response as argument.
Class GuzzleHttp\Exception\ConnectException now extends GuzzleHttp\Exception\TransferException instead of GuzzleHttp\Exception\RequestException.
Function GuzzleHttp\Exception\ConnectException::getResponse() is removed.
Function GuzzleHttp\Exception\ConnectException::hasResponse() is removed.
Constant GuzzleHttp\ClientInterface::VERSION is removed. Added GuzzleHttp\ClientInterface::MAJOR_VERSION instead.
Function GuzzleHttp\Exception\RequestException::getResponseBodySummary is removed. Use \GuzzleHttp\Psr7\get_message_body_summary as an alternative.
Function GuzzleHttp\Cookie\CookieJar::getCookieValue is removed.
Request option exception is removed. Please use http_errors.
Request option save_to is removed. Please use sink.
Pool option pool_size is removed. Please use concurrency.
We now look for environment variables in the $_SERVER super global, due to thread safety issues with getenv. We continue to fallback to getenv in CLI environments, for maximum compatibility.
The get, head, put, post, patch, delete, getAsync, headAsync, putAsync, postAsync, patchAsync, and deleteAsync methods are now implemented as genuine methods on GuzzleHttp\Client, with strong typing. The original __call implementation remains unchanged for now, for maximum backwards compatibility, but won't be invoked under normal operation.
The log middleware will log the errors with level error instead of notice
Support for international domain names (IDN) is now disabled by default, and enabling it requires installing ext-intl, linked against a modern version of the C library (ICU 4.6 or higher).

https://github.com/guzzle/guzzle/blob/master/UPGRADING.md