### PR TITLE
Update PlivoRequest.php

### DIFF
--- a/src/Plivo/Http/PlivoRequest.php
+++ b/src/Plivo/Http/PlivoRequest.php
@@ -257,7 +257,7 @@ class PlivoRequest
             return $url;
         }
 
-        $getParams =  http_build_query($params, null, '&');
+        $getParams =  http_build_query($params, "", '&');
 
         return $url . '?' . $getParams;
     }


### PR DESCRIPTION
Fix http_build_query in PHP8

Exception Message in PHP8:
http_build_query(): Passing null to parameter https://github.com/getkirby/kirby/issues/2 ($numeric_prefix) of type string is deprecated