### PR TITLE
Edge case fix: handle multiple dst number added on request param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## [v4.46.1](https://github.com/plivo/plivo-php/tree/v4.46.1) (2023-05-04)
+- Fix send sms api failure on multiple destination number added on array param
 
 ## [v4.46.0](https://github.com/plivo/plivo-php/tree/v4.46.0) (2023-04-25)
 - Add `replacedSender` to the response for the [list all messages API](https://www.plivo.com/docs/sms/api/message/list-all-messages/) and the [get message details API](https://www.plivo.com/docs/sms/api/message#retrieve-a-message)

--- a/src/Plivo/Resources/Message/MessageInterface.php
+++ b/src/Plivo/Resources/Message/MessageInterface.php
@@ -176,7 +176,7 @@ class MessageInterface extends ResourceInterface
 
         $response = $this->client->update(
             $this->uri,
-            array_merge($mandatoryArgs, $optionalArgs, ['src' => $src, 'powerpack_uuid' => $powerpackUUID, 'text' => $text])
+            array_merge($mandatoryArgs, ['src' => $src, 'powerpack_uuid' => $powerpackUUID, 'text' => $text], $optionalArgs)
         );
 
         $responseContents = $response->getContent();

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -25,7 +25,7 @@ class Version
     /**
      * @const int PHP helper library patch number
      */
-    const PATCH = 0;
+    const PATCH = 1;
     /**
      * @return string
      */


### PR DESCRIPTION
example: 
$array1 = [1, 2, 3];
$array2 = [];
$result = array_merge($array1, $array2);
print_r($result);

output:
Array
(
    [0] => 1
    [1] => 2
    [2] => 3
)
