### PR TITLE
MPT- 6863: Add fix for deprecated implicit nullable warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.66.6](https://github.com/plivo/plivo-php/tree/v4.66.6) (2025-03-14)
+**Enhancement - Fix implicit nullable warning .**
+- Fix warnings related to implicit nullable declaration from PHP 8.4.
+
 ## [4.66.5](https://github.com/plivo/plivo-php/tree/v4.66.5) (2025-02-25)
 **Enhancement - Supporting parameter_name in WhatsApp Template .**
 - Supporting `parameter_name` in WhatsApp Template .

--- a/src/Plivo/Http/PlivoResponse.php
+++ b/src/Plivo/Http/PlivoResponse.php
@@ -53,7 +53,7 @@ class PlivoResponse
      * @param array|null      $headers The headers of the response
      */
     public function __construct(
-        PlivoRequest $request = null,
+        ?PlivoRequest $request = null,
         $httpStatusCode = null,
         $content = null,
         array $headers = [])

--- a/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
+++ b/src/Plivo/HttpClients/PlivoGuzzleHttpClient.php
@@ -44,8 +44,8 @@ class PlivoGuzzleHttpClient implements PlivoHttpClientInterface
      * @internal param Client|null $Handler .
      */
     public function __construct(
-        Client $guzzleClient = null,
-        BasicAuth $basicAuth = null,
+        ?Client $guzzleClient = null,
+        ?BasicAuth $basicAuth = null,
         $proxyHost = null,
         $proxyPort = null,
         $proxyUsername = null,

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -26,7 +26,7 @@ class Version
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 5;
+    const PATCH = 6;
 
     /**
      * @return string


### PR DESCRIPTION
Avoid warning related to implicitly nullable declaration for Php version 8.4 and above.

Ref - https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated