### PR TITLE
fix: link response returns full fields + bump to 4.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.69.2](https://github.com/plivo/plivo-php/tree/v4.69.2) (2026-04-15)
+**Bug Fix - PhoneNumber Compliance multipart file field naming**
+- Fixed multipart file upload field names from `file_N` to `documents[N].file` to match the API's expected format
+
 ## [4.69.1](https://github.com/plivo/plivo-php/tree/v4.69.1) (2026-04-17)
 **Bug Fix - PhoneNumber Compliance API**
 - Fixed Link response to return `total_count`, `updated_count`, and `report` fields instead of generic `ResponseUpdate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [4.69.1](https://github.com/plivo/plivo-php/tree/v4.69.1) (2026-04-17)
+**Bug Fix - PhoneNumber Compliance API**
+- Fixed Link response to return `total_count`, `updated_count`, and `report` fields instead of generic `ResponseUpdate`
+- Fixed Requirements params and multipart handling for create/update
+
 ## [4.69.0](https://github.com/plivo/plivo-php/tree/v4.69.0) (2026-04-08)
 **Feature - PhoneNumber Compliance API support**
 - Added `phoneNumberComplianceRequirement` resource for discovering compliance requirements by country, number type, and user type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-## [4.69.2](https://github.com/plivo/plivo-php/tree/v4.69.2) (2026-04-15)
-**Bug Fix - PhoneNumber Compliance multipart file field naming**
-- Fixed multipart file upload field names from `file_N` to `documents[N].file` to match the API's expected format
-
 ## [4.69.1](https://github.com/plivo/plivo-php/tree/v4.69.1) (2026-04-17)
 **Bug Fix - PhoneNumber Compliance API**
 - Fixed Link response to return `total_count`, `updated_count`, and `report` fields instead of generic `ResponseUpdate`
 - Fixed Requirements params and multipart handling for create/update
+- Fixed multipart file upload field names from `file_N` to `documents[N].file` to match the API's expected format
 
 ## [4.69.0](https://github.com/plivo/plivo-php/tree/v4.69.0) (2026-04-08)
 **Feature - PhoneNumber Compliance API support**

--- a/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceInterface.php
+++ b/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceInterface.php
@@ -52,8 +52,8 @@ class PhoneNumberComplianceInterface extends ResourceInterface
 
         foreach ($documentPaths as $index => $path) {
             $multipart[] = [
-                'name' => 'file_' . $index,
-                'contents' => file_get_contents($path),
+                'name' => 'documents[' . $index . '].file',
+                'contents' => fopen($path, 'r'),
                 'filename' => basename($path),
             ];
         }

--- a/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceInterface.php
+++ b/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceInterface.php
@@ -51,9 +51,13 @@ class PhoneNumberComplianceInterface extends ResourceInterface
         ];
 
         foreach ($documentPaths as $index => $path) {
+            $handle = fopen($path, 'r');
+            if ($handle === false) {
+                throw new PlivoValidationException("File not found: " . $path);
+            }
             $multipart[] = [
                 'name' => 'documents[' . $index . '].file',
-                'contents' => fopen($path, 'r'),
+                'contents' => $handle,
                 'filename' => basename($path),
             ];
         }
@@ -89,10 +93,10 @@ class PhoneNumberComplianceInterface extends ResourceInterface
             );
         } else {
             throw new PlivoResponseException(
-                "",
+                $responseContents['error'] ?? "",
                 0,
                 null,
-                $response->getContent(),
+                $responseContents,
                 $response->getStatusCode()
             );
         }
@@ -217,10 +221,10 @@ class PhoneNumberComplianceInterface extends ResourceInterface
             );
         } else {
             throw new PlivoResponseException(
-                "",
+                $responseContents['error'] ?? "",
                 0,
                 null,
-                $response->getContent(),
+                $responseContents,
                 $response->getStatusCode()
             );
         }

--- a/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceLinkInterface.php
+++ b/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceLinkInterface.php
@@ -8,7 +8,6 @@ use Plivo\Exceptions\PlivoResponseException;
 use Plivo\BaseClient;
 
 use Plivo\Resources\ResourceInterface;
-use Plivo\Resources\ResponseUpdate;
 use Plivo\Util\ArrayOperations;
 
 /**
@@ -34,7 +33,7 @@ class PhoneNumberComplianceLinkInterface extends ResourceInterface
     /**
      * Link numbers to a compliance
      * @param array $numbers
-     * @return ResponseUpdate
+     * @return array
      * @throws PlivoValidationException
      * @throws PlivoResponseException
      */
@@ -47,25 +46,21 @@ class PhoneNumberComplianceLinkInterface extends ResourceInterface
 
         $response = $this->client->update(
             $this->uri,
-            $numbers
+            ['numbers' => $numbers]
         );
 
         $responseContents = $response->getContent();
 
-        if(!array_key_exists("error", $responseContents)){
-            return new ResponseUpdate(
-                $responseContents['api_id'],
-                $responseContents['message'],
-                $response->getStatusCode()
-            );
-        } else {
+        if(array_key_exists("error", $responseContents)){
             throw new PlivoResponseException(
                 "",
                 0,
                 null,
-                $response->getContent(),
+                $responseContents,
                 $response->getStatusCode()
             );
         }
+
+        return $responseContents;
     }
 }

--- a/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceLinkInterface.php
+++ b/src/Plivo/Resources/PhoneNumberCompliance/PhoneNumberComplianceLinkInterface.php
@@ -46,14 +46,14 @@ class PhoneNumberComplianceLinkInterface extends ResourceInterface
 
         $response = $this->client->update(
             $this->uri,
-            ['numbers' => $numbers]
+            $numbers
         );
 
         $responseContents = $response->getContent();
 
         if(array_key_exists("error", $responseContents)){
             throw new PlivoResponseException(
-                "",
+                $responseContents['error'] ?? "",
                 0,
                 null,
                 $responseContents,

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -26,7 +26,7 @@ class Version
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 1;
+    const PATCH = 2;
 
     /**
      * @return string

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -26,7 +26,7 @@ class Version
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 0;
+    const PATCH = 1;
 
     /**
      * @return string

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -26,7 +26,7 @@ class Version
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 2;
+    const PATCH = 1;
 
     /**
      * @return string

--- a/tests/Resources/PhoneNumberComplianceTest.php
+++ b/tests/Resources/PhoneNumberComplianceTest.php
@@ -443,8 +443,8 @@ class PhoneNumberComplianceTest extends BaseTestCase
         $this->assertRequest($request);
 
         self::assertNotNull($actual);
-        self::assertEquals('Numbers linked successfully.', $actual->getMessage());
-        self::assertEquals('afd51000-31aa-11f1-ab48-d2d6f5435dea', $actual->getApiId());
+        self::assertEquals('Numbers linked successfully.', $actual['message']);
+        self::assertEquals('afd51000-31aa-11f1-ab48-d2d6f5435dea', $actual['api_id']);
     }
 
     function testLinkEmptyReport()
@@ -467,7 +467,7 @@ class PhoneNumberComplianceTest extends BaseTestCase
         $this->assertRequest($request);
 
         self::assertNotNull($actual);
-        self::assertEquals('No numbers were linked.', $actual->getMessage());
+        self::assertEquals('No numbers were linked.', $actual['message']);
     }
 
     function testLinkRequestBodyStructure()


### PR DESCRIPTION
Return raw response array from link() instead of ResponseUpdate, exposing total_count, updated_count, and report fields. Bump version to 4.69.1.