### PR TITLE
feat: expose sub_account_name on Number resource

### DIFF
--- a/src/Plivo/Resources/Number/Number.php
+++ b/src/Plivo/Resources/Number/Number.php
@@ -36,6 +36,8 @@ use Plivo\Resources\Resource;
  * @property string $complianceStatus The status of the compliance application associated with this number.
  * @property string $subAccount The subaccount associated with the number. If the number belongs to the main parent
  * account, this value will be null.
+ * @property string $subAccountName The name of the subaccount associated with the number. Null if the number belongs
+ * to the main parent account or the subaccount has no name set.
  */
 class Number extends Resource
 {
@@ -67,6 +69,7 @@ class Number extends Resource
             'mmsEnabled' => isset($response['mms_enabled']) ? $response['mms_enabled'] : null,
             'mmsRate' => isset($response['mms_rate']) ? $response['mms_rate'] : null,
             'subAccount' => $response['sub_account'],
+            'subAccountName' => isset($response['sub_account_name']) ? $response['sub_account_name'] : null,
             'voiceEnabled' => $response['voice_enabled'],
             'voiceRate' => $response['voice_rate'],
             'complianceApplicationId' => isset($response['compliance_application_id']) ? $response['compliance_application_id'] : null,


### PR DESCRIPTION
## Summary

Adds `subAccountName` property to the `Number` resource model, mirroring the new `sub_account_name` field added to `GET /v1/Account/{auth_id}/Number/` listing responses.

Companion to:
- plivo/pkg#168 (merged) — adds `SubAccountName` on `AuthInfoResponse`
- plivo/number_service#743 — populates `sub_account_name` in the rented-numbers response
- plivo/message-router#291 — analogous change for senderid listing

## Test plan

- [ ] CI build green
- [ ] Verify against a staging response that returns `sub_account_name` for subaccount-owned numbers and `null` for parent-account numbers