### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.69.3](https://github.com/plivo/plivo-php/tree/v4.69.3) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [4.69.2](https://github.com/plivo/plivo-php/tree/v4.69.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/src/Plivo/Resources/Profile/ProfileInterface.php
+++ b/src/Plivo/Resources/Profile/ProfileInterface.php
@@ -101,9 +101,10 @@ class ProfileInterface extends ResourceInterface
      * @param {string} country
      * @param {string} business_contact_email
      * @param {string} doing_business_as Doing Business As (customer-facing name, optional)
+     * @param {string} number_of_employees Number of employees (optional). Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
      * @return profileResponse response output
      */
-    public function create($profile_alias,$plivo_subaccount,$customer_type,$entity_type, $company_name,$ein,$vertical,$ein_issuing_country,$stock_symbol,$stock_exchange, $alt_business_id_type, $website, $address, $authorized_contact, $business_contact_email = '', $doing_business_as = '', $optionalArgs = [])
+    public function create($profile_alias,$plivo_subaccount,$customer_type,$entity_type, $company_name,$ein,$vertical,$ein_issuing_country,$stock_symbol,$stock_exchange, $alt_business_id_type, $website, $address, $authorized_contact, $business_contact_email = '', $doing_business_as = '', $number_of_employees = '', $optionalArgs = [])
     {
         $mandaoryArgs = [
             'profile_alias' => $profile_alias,
@@ -125,6 +126,9 @@ class ProfileInterface extends ResourceInterface
         if ($doing_business_as !== '') {
             $optionalArgs['doing_business_as'] = $doing_business_as;
         }
+        if ($number_of_employees !== '') {
+            $optionalArgs['number_of_employees'] = $number_of_employees;
+        }
         $response = $this->client->update(
             $this->uri .'Profile/',
             array_merge($mandaoryArgs, $optionalArgs)
@@ -145,6 +149,7 @@ class ProfileInterface extends ResourceInterface
      * @param{string} website
      * @param{string} business_contact_email
      * @param{string} doing_business_as Doing Business As (customer-facing name, optional)
+     * @param{string} number_of_employees Number of employees (optional). Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
      * @return profileResponse response output
      */
     public function update($profile_uuid, array $optionalArgs = [])

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -26,7 +26,7 @@ class Version
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 2;
+    const PATCH = 3;
 
     /**
      * @return string

--- a/tests/Resources/ProfileTest.php
+++ b/tests/Resources/ProfileTest.php
@@ -99,7 +99,8 @@ class ProfileTest extends BaseTestCase {
                     'title' => 'CEO',
                     'seniority' => 'C_LEVEL'
                 ],
-                'doing_business_as' => 'Test DBA'
+                'doing_business_as' => 'Test DBA',
+                'number_of_employees' => 'BETWEEN_51_AND_200'
             ]);
         $body = file_get_contents(__DIR__ . '/../Mocks/profileCreateResponse.json');
 
@@ -134,7 +135,8 @@ class ProfileTest extends BaseTestCase {
                 'seniority' => 'C_LEVEL'
             ],
             'employee@company.com',
-            'Test DBA'
+            'Test DBA',
+            'BETWEEN_51_AND_200'
         );
 
         $this->assertRequest($request);


### PR DESCRIPTION
## Summary
Adds an optional `number_of_employees` string field to the Profile (10DLC/A2P account profile) create & update APIs. This mirrors a backend change in campaign-service where `number_of_employees` was added to the Profile create/update request as an optional string.

The implementation follows the recently added `doing_business_as` (DBA) field exactly — same files, same positions (immediately after DBA), same style.

## Changes
- `src/Plivo/Resources/Profile/ProfileInterface.php`: added `$number_of_employees = ''` param to `create()` (after `$doing_business_as`), conditional inclusion into the request args, and documented the 7 allowed values in the `create()`/`update()` docblocks. No client-side enum validation (server validates).
- `tests/Resources/ProfileTest.php`: added `number_of_employees` to the expected request payload and the `create()` call args, mirroring DBA.
- `src/Plivo/Version.php`: patch bump `4.69.2` → `4.69.3`.
- `CHANGELOG.md`: new `4.69.3` entry dated 2026-06-10.

### Allowed values (documented, not enforced)
`BETWEEN_1_AND_10`, `BETWEEN_11_AND_50`, `BETWEEN_51_AND_200`, `BETWEEN_201_AND_500`, `BETWEEN_501_AND_2000`, `BETWEEN_2001_AND_10000`, `MORE_THAN_10001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)