### PR TITLE
feat: add complianceApplicationId param to phone number buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.70.0](https://github.com/plivo/plivo-php/tree/v4.70.0) (2026-06-11)
+**Feature - PhoneNumber Buy compliance application support**
+- Added optional `complianceApplicationId` parameter to the `phoneNumbers->buy` method, serialized as `compliance_application_id` on the request. This allows linking a regulatory compliance application to a number at purchase time (required for regulated numbers, e.g. India).
+
 ## [4.69.2](https://github.com/plivo/plivo-php/tree/v4.69.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/src/Plivo/Resources/PhoneNumber/PhoneNumberInterface.php
+++ b/src/Plivo/Resources/PhoneNumber/PhoneNumberInterface.php
@@ -91,13 +91,17 @@ class PhoneNumberInterface extends ResourceInterface
      * @param string|null $appId
      * @param string|null $cnamLookup
      * @param bool|null $haEnable
+     * @param string|null $complianceApplicationId - The ID of the regulatory compliance application to link to the number at purchase time. Required for regulated numbers (e.g. India).
      * @return PhoneNumberBuyResponse output
      */
-    public function buy($phoneNumber, $appId = null, $cnamLookup = null, $haEnable = null)
+    public function buy($phoneNumber, $appId = null, $cnamLookup = null, $haEnable = null, $complianceApplicationId = null)
     {
         $data = ['app_id'=>$appId,'cnam_lookup'=>$cnamLookup];
         if (!is_null($haEnable)) {
             $data['ha_enable'] = $haEnable;
+        }
+        if (!is_null($complianceApplicationId)) {
+            $data['compliance_application_id'] = $complianceApplicationId;
         }
         $response = $this->client->update(
             $this->uri . $phoneNumber . '/',

--- a/src/Plivo/Version.php
+++ b/src/Plivo/Version.php
@@ -20,13 +20,13 @@ class Version
     /**
      * @const int PHP helper library minor version number
      */
-    const MINOR = 69;
+    const MINOR = 70;
 
     /**
      * @const int PHP helper library patch number
      */
 
-    const PATCH = 2;
+    const PATCH = 0;
 
     /**
      * @return string

--- a/tests/Resources/PhoneNumberTest.php
+++ b/tests/Resources/PhoneNumberTest.php
@@ -47,4 +47,23 @@ class PhoneNumberTest extends BaseTestCase
 
         self::assertNotNull($actual);
     }
+
+    function testPhoneNumberBuyWithComplianceApplicationId()
+    {
+        $number = 'sadasdasd';
+        $complianceApplicationId = 'COMPLIANCE123456789';
+        $request = new PlivoRequest(
+            'POST',
+            'Account/MAXXXXXXXXXXXXXXXXXX/PhoneNumber/' . $number . '/',
+            ['compliance_application_id' => $complianceApplicationId]);
+        $body = file_get_contents(__DIR__ . '/../Mocks/phoneNumberCreateResponse.json');
+
+        $this->mock(new PlivoResponse($request,201, $body));
+
+        $actual = $this->client->phoneNumbers->buy($number, null, null, null, $complianceApplicationId);
+
+        $this->assertRequest($request);
+
+        self::assertNotNull($actual);
+    }
 }


### PR DESCRIPTION
## What
Adds an optional trailing `complianceApplicationId` parameter to `PhoneNumberInterface::buy`, serialized as the `compliance_application_id` wire param on the purchase request. Previously `buy` only sent `app_id`, `cnam_lookup`, and `ha_enable`.

## Why
Regulated numbers (e.g. India) require an approved regulatory compliance application to be linked to the number at purchase time. This lets callers pass that application ID directly into `buy`. The new param is a trailing optional argument, so the change is fully backward-compatible.

## Testing
PhoneNumber tests pass:
```
php vendor/bin/phpunit --bootstrap tests/bootstrap.php --filter 'PhoneNumberTest' tests
OK (3 tests, 6 assertions)
```
Note: there are 3 pre-existing, unrelated failures on master (CampaignTest x2, UtilTest::testJWT) that are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)